### PR TITLE
feat: add kubecopilot CLI for managing agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/*
+cli
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager ./cmd/main.go
 
+.PHONY: build-cli
+build-cli: fmt vet ## Build the kubecopilot CLI binary.
+	go build -o bin/kubecopilot ./cmd/cli/
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go

--- a/cmd/cli/agent.go
+++ b/cmd/cli/agent.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,12 +47,12 @@ var agentListCmd = &cobra.Command{
 		if err := c.List(context.Background(), &list, client.InNamespace(namespace)); err != nil {
 			return fmt.Errorf("failed to list agents: %w", err)
 		}
-		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tPHASE\tAGENT ID\tAGE")
+		w := newStdoutTabWriterHelper()
+		w.Println("NAME\tPHASE\tAGENT ID\tAGE")
 		for i := range list.Items {
 			a := &list.Items[i]
 			age := formatAge(a.CreationTimestamp.Time)
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", a.Name, a.Status.Phase, a.Status.AgentID, age)
+			w.Printf("%s\t%s\t%s\t%s\n", a.Name, a.Status.Phase, a.Status.AgentID, age)
 		}
 		return w.Flush()
 	},
@@ -75,30 +74,30 @@ var agentGetCmd = &cobra.Command{
 		if err := c.Get(context.Background(), key, &agent); err != nil {
 			return fmt.Errorf("failed to get agent %q: %w", args[0], err)
 		}
-		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "Name:\t%s\n", agent.Name)
-		fmt.Fprintf(w, "Namespace:\t%s\n", agent.Namespace)
-		fmt.Fprintf(w, "Phase:\t%s\n", agent.Status.Phase)
-		fmt.Fprintf(w, "Agent ID:\t%s\n", agent.Status.AgentID)
-		fmt.Fprintf(w, "Token Secret:\t%s\n", agent.Spec.GitHubTokenSecretRef.Name)
+		w := newStdoutTabWriterHelper()
+		w.Printf("Name:\t%s\n", agent.Name)
+		w.Printf("Namespace:\t%s\n", agent.Namespace)
+		w.Printf("Phase:\t%s\n", agent.Status.Phase)
+		w.Printf("Agent ID:\t%s\n", agent.Status.AgentID)
+		w.Printf("Token Secret:\t%s\n", agent.Spec.GitHubTokenSecretRef.Name)
 		if agent.Spec.Image != "" {
-			fmt.Fprintf(w, "Image:\t%s\n", agent.Spec.Image)
+			w.Printf("Image:\t%s\n", agent.Spec.Image)
 		}
-		fmt.Fprintf(w, "Storage Size:\t%s\n", agent.Spec.StorageSize)
+		w.Printf("Storage Size:\t%s\n", agent.Spec.StorageSize)
 		if agent.Spec.SkillsConfigMap != "" {
-			fmt.Fprintf(w, "Skills ConfigMap:\t%s\n", agent.Spec.SkillsConfigMap)
+			w.Printf("Skills ConfigMap:\t%s\n", agent.Spec.SkillsConfigMap)
 		}
 		if agent.Spec.AgentConfigMap != "" {
-			fmt.Fprintf(w, "Agent ConfigMap:\t%s\n", agent.Spec.AgentConfigMap)
+			w.Printf("Agent ConfigMap:\t%s\n", agent.Spec.AgentConfigMap)
 		}
 		if agent.Status.ServiceName != "" {
-			fmt.Fprintf(w, "Service:\t%s\n", agent.Status.ServiceName)
+			w.Printf("Service:\t%s\n", agent.Status.ServiceName)
 		}
 		if len(agent.Status.Conditions) > 0 {
-			fmt.Fprintln(w, "\nConditions:")
-			fmt.Fprintln(w, "  TYPE\tSTATUS\tREASON\tMESSAGE")
+			w.Println("\nConditions:")
+			w.Println("  TYPE\tSTATUS\tREASON\tMESSAGE")
 			for _, cond := range agent.Status.Conditions {
-				fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n",
+				w.Printf("  %s\t%s\t%s\t%s\n",
 					cond.Type, cond.Status, cond.Reason, cond.Message)
 			}
 		}
@@ -149,7 +148,7 @@ var agentCreateCmd = &cobra.Command{
 		if err := c.Create(context.Background(), agent); err != nil {
 			return fmt.Errorf("failed to create agent: %w", err)
 		}
-		fmt.Fprintf(os.Stdout, "agent/%s created\n", args[0])
+		_, _ = fmt.Fprintf(os.Stdout, "agent/%s created\n", args[0])
 		return nil
 	},
 }
@@ -174,13 +173,14 @@ var agentDeleteCmd = &cobra.Command{
 		if err := c.Delete(context.Background(), agent); err != nil {
 			return fmt.Errorf("failed to delete agent %q: %w", args[0], err)
 		}
-		fmt.Fprintf(os.Stdout, "agent/%s deleted\n", args[0])
+		_, _ = fmt.Fprintf(os.Stdout, "agent/%s deleted\n", args[0])
 		return nil
 	},
 }
 
 func init() {
-	agentCreateCmd.Flags().StringVar(&agentTokenSecret, "token-secret", "", "name of the Secret containing GITHUB_TOKEN (required)")
+	agentCreateCmd.Flags().StringVar(&agentTokenSecret, "token-secret", "",
+		"name of the Secret containing GITHUB_TOKEN (required)")
 	agentCreateCmd.Flags().StringVar(&agentImage, "image", "", "override the default agent container image")
 	agentCreateCmd.Flags().StringVar(&agentStorageSize, "storage-size", "", "PVC size for session state (default: 1Gi)")
 	agentCreateCmd.Flags().StringVar(&agentSkillsCM, "skills-configmap", "", "name of the skills ConfigMap")

--- a/cmd/cli/agent.go
+++ b/cmd/cli/agent.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentv1 "github.com/gfontana/kube-copilot-agent/api/v1"
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Manage KubeCopilotAgent resources",
+}
+
+// --- list ---
+
+var agentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List KubeCopilotAgent resources",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		var list agentv1.KubeCopilotAgentList
+		if err := c.List(context.Background(), &list, client.InNamespace(namespace)); err != nil {
+			return fmt.Errorf("failed to list agents: %w", err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tPHASE\tAGENT ID\tAGE")
+		for i := range list.Items {
+			a := &list.Items[i]
+			age := formatAge(a.CreationTimestamp.Time)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", a.Name, a.Status.Phase, a.Status.AgentID, age)
+		}
+		return w.Flush()
+	},
+}
+
+// --- get ---
+
+var agentGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Get details of a KubeCopilotAgent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		var agent agentv1.KubeCopilotAgent
+		key := client.ObjectKey{Namespace: namespace, Name: args[0]}
+		if err := c.Get(context.Background(), key, &agent); err != nil {
+			return fmt.Errorf("failed to get agent %q: %w", args[0], err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(w, "Name:\t%s\n", agent.Name)
+		fmt.Fprintf(w, "Namespace:\t%s\n", agent.Namespace)
+		fmt.Fprintf(w, "Phase:\t%s\n", agent.Status.Phase)
+		fmt.Fprintf(w, "Agent ID:\t%s\n", agent.Status.AgentID)
+		fmt.Fprintf(w, "Token Secret:\t%s\n", agent.Spec.GitHubTokenSecretRef.Name)
+		if agent.Spec.Image != "" {
+			fmt.Fprintf(w, "Image:\t%s\n", agent.Spec.Image)
+		}
+		fmt.Fprintf(w, "Storage Size:\t%s\n", agent.Spec.StorageSize)
+		if agent.Spec.SkillsConfigMap != "" {
+			fmt.Fprintf(w, "Skills ConfigMap:\t%s\n", agent.Spec.SkillsConfigMap)
+		}
+		if agent.Spec.AgentConfigMap != "" {
+			fmt.Fprintf(w, "Agent ConfigMap:\t%s\n", agent.Spec.AgentConfigMap)
+		}
+		if agent.Status.ServiceName != "" {
+			fmt.Fprintf(w, "Service:\t%s\n", agent.Status.ServiceName)
+		}
+		if len(agent.Status.Conditions) > 0 {
+			fmt.Fprintln(w, "\nConditions:")
+			fmt.Fprintln(w, "  TYPE\tSTATUS\tREASON\tMESSAGE")
+			for _, cond := range agent.Status.Conditions {
+				fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n",
+					cond.Type, cond.Status, cond.Reason, cond.Message)
+			}
+		}
+		return w.Flush()
+	},
+}
+
+// --- create ---
+
+var (
+	agentTokenSecret string
+	agentImage       string
+	agentStorageSize string
+	agentSkillsCM    string
+	agentAgentCM     string
+)
+
+var agentCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a new KubeCopilotAgent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		agent := &agentv1.KubeCopilotAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      args[0],
+				Namespace: namespace,
+			},
+			Spec: agentv1.KubeCopilotAgentSpec{
+				GitHubTokenSecretRef: agentv1.SecretReference{Name: agentTokenSecret},
+			},
+		}
+		if agentImage != "" {
+			agent.Spec.Image = agentImage
+		}
+		if agentStorageSize != "" {
+			agent.Spec.StorageSize = agentStorageSize
+		}
+		if agentSkillsCM != "" {
+			agent.Spec.SkillsConfigMap = agentSkillsCM
+		}
+		if agentAgentCM != "" {
+			agent.Spec.AgentConfigMap = agentAgentCM
+		}
+		if err := c.Create(context.Background(), agent); err != nil {
+			return fmt.Errorf("failed to create agent: %w", err)
+		}
+		fmt.Fprintf(os.Stdout, "agent/%s created\n", args[0])
+		return nil
+	},
+}
+
+// --- delete ---
+
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a KubeCopilotAgent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		agent := &agentv1.KubeCopilotAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      args[0],
+				Namespace: namespace,
+			},
+		}
+		if err := c.Delete(context.Background(), agent); err != nil {
+			return fmt.Errorf("failed to delete agent %q: %w", args[0], err)
+		}
+		fmt.Fprintf(os.Stdout, "agent/%s deleted\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	agentCreateCmd.Flags().StringVar(&agentTokenSecret, "token-secret", "", "name of the Secret containing GITHUB_TOKEN (required)")
+	agentCreateCmd.Flags().StringVar(&agentImage, "image", "", "override the default agent container image")
+	agentCreateCmd.Flags().StringVar(&agentStorageSize, "storage-size", "", "PVC size for session state (default: 1Gi)")
+	agentCreateCmd.Flags().StringVar(&agentSkillsCM, "skills-configmap", "", "name of the skills ConfigMap")
+	agentCreateCmd.Flags().StringVar(&agentAgentCM, "agent-configmap", "", "name of the agent ConfigMap")
+	_ = agentCreateCmd.MarkFlagRequired("token-secret")
+
+	agentCmd.AddCommand(agentListCmd)
+	agentCmd.AddCommand(agentGetCmd)
+	agentCmd.AddCommand(agentCreateCmd)
+	agentCmd.AddCommand(agentDeleteCmd)
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -118,7 +118,7 @@ var dashboardCmd = &cobra.Command{
 			close(stopChan)
 		}()
 
-		fmt.Fprintf(os.Stdout, "Forwarding %s/%s → http://localhost:%d\n", namespace, podName, dashboardPort)
+		_, _ = fmt.Fprintf(os.Stdout, "Forwarding %s/%s → http://localhost:%d\n", namespace, podName, dashboardPort)
 		return pf.ForwardPorts()
 	},
 }

--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var dashboardPort int
+
+var dashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Port-forward the KubeCopilot Web UI to localhost",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := getRestConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get kubeconfig: %w", err)
+		}
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		// Find the web-ui service.
+		var svcList corev1.ServiceList
+		if err := c.List(context.Background(), &svcList, client.InNamespace(namespace)); err != nil {
+			return fmt.Errorf("failed to list services: %w", err)
+		}
+		var targetSvc *corev1.Service
+		for i := range svcList.Items {
+			s := &svcList.Items[i]
+			if s.Name == "kube-copilot-agent-ui" || s.Name == "web-ui" {
+				targetSvc = s
+				break
+			}
+		}
+		if targetSvc == nil {
+			return fmt.Errorf("web-ui service not found in namespace %q", namespace)
+		}
+
+		// Determine target port from the service.
+		var svcPort int32 = 3000
+		if len(targetSvc.Spec.Ports) > 0 {
+			svcPort = targetSvc.Spec.Ports[0].TargetPort.IntVal
+			if svcPort == 0 {
+				svcPort = targetSvc.Spec.Ports[0].Port
+			}
+		}
+
+		// Find a pod backing the service.
+		var podList corev1.PodList
+		if err := c.List(context.Background(), &podList,
+			client.InNamespace(namespace),
+			client.MatchingLabels(targetSvc.Spec.Selector)); err != nil {
+			return fmt.Errorf("failed to list pods: %w", err)
+		}
+		if len(podList.Items) == 0 {
+			return fmt.Errorf("no pods found for service %q", targetSvc.Name)
+		}
+		podName := podList.Items[0].Name
+
+		// Set up port-forward.
+		clientset, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create clientset: %w", err)
+		}
+		req := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Namespace(namespace).
+			Name(podName).
+			SubResource("portforward")
+
+		transport, upgrader, err := spdy.RoundTripperFor(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create round tripper: %w", err)
+		}
+		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL())
+
+		stopChan := make(chan struct{}, 1)
+		readyChan := make(chan struct{})
+		ports := []string{fmt.Sprintf("%d:%d", dashboardPort, svcPort)}
+
+		pf, err := portforward.New(dialer, ports, stopChan, readyChan, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("failed to create port-forward: %w", err)
+		}
+
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			close(stopChan)
+		}()
+
+		fmt.Fprintf(os.Stdout, "Forwarding %s/%s → http://localhost:%d\n", namespace, podName, dashboardPort)
+		return pf.ForwardPorts()
+	},
+}
+
+func init() {
+	dashboardCmd.Flags().IntVar(&dashboardPort, "port", 3000, "local port to forward to")
+	rootCmd.AddCommand(dashboardCmd)
+}

--- a/cmd/cli/helpers.go
+++ b/cmd/cli/helpers.go
@@ -18,6 +18,9 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
 	"time"
 )
 
@@ -34,4 +37,48 @@ func formatAge(t time.Time) string {
 	default:
 		return fmt.Sprintf("%dd", int(d.Hours()/24))
 	}
+}
+
+// tabWriterHelper wraps a *tabwriter.Writer and accumulates the first write
+// error so callers can check errors at the end via Flush() instead of after
+// each individual write. Only the first write error is preserved; subsequent
+// writes are silently skipped once an error has occurred. This pattern is
+// safe because tabwriter buffers all output and errors are propagated through
+// Flush() anyway.
+type tabWriterHelper struct {
+	tw  *tabwriter.Writer
+	err error
+}
+
+func newTabWriterHelper(w io.Writer) *tabWriterHelper {
+	return &tabWriterHelper{tw: tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)}
+}
+
+func newStdoutTabWriterHelper() *tabWriterHelper {
+	return newTabWriterHelper(os.Stdout)
+}
+
+// Printf formats and writes to the underlying tabwriter.
+// If a previous write already failed the call is a no-op.
+func (t *tabWriterHelper) Printf(format string, args ...any) {
+	if t.err != nil {
+		return
+	}
+	_, t.err = fmt.Fprintf(t.tw, format, args...)
+}
+
+// Println writes s followed by a newline to the underlying tabwriter.
+// If a previous write already failed the call is a no-op.
+func (t *tabWriterHelper) Println(s string) {
+	if t.err != nil {
+		return
+	}
+	_, t.err = fmt.Fprintln(t.tw, s)
+}
+
+func (t *tabWriterHelper) Flush() error {
+	if t.err != nil {
+		return t.err
+	}
+	return t.tw.Flush()
 }

--- a/cmd/cli/helpers.go
+++ b/cmd/cli/helpers.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// formatAge returns a human-readable duration string similar to kubectl output.
+func formatAge(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -42,7 +42,7 @@ var installCmd = &cobra.Command{
 		if installVersion != "" && installVersion != defaultVersion {
 			url = fmt.Sprintf(manifestURLTmpl, installVersion)
 		}
-		fmt.Fprintf(os.Stdout, "Installing KubeCopilot operator from %s\n", url)
+		_, _ = fmt.Fprintf(os.Stdout, "Installing KubeCopilot operator from %s\n", url)
 		return runKubectl("apply", "-f", url)
 	},
 }
@@ -56,7 +56,7 @@ var uninstallCmd = &cobra.Command{
 		if installVersion != "" && installVersion != defaultVersion {
 			url = fmt.Sprintf(manifestURLTmpl, installVersion)
 		}
-		fmt.Fprintf(os.Stdout, "Uninstalling KubeCopilot operator using %s\n", url)
+		_, _ = fmt.Fprintf(os.Stdout, "Uninstalling KubeCopilot operator using %s\n", url)
 		return runKubectl("delete", "--ignore-not-found", "-f", url)
 	},
 }

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultVersion  = "latest"
+	releaseBaseURL  = "https://github.com/gfontana/kube-copilot-agent/releases"
+	manifestURLTmpl = releaseBaseURL + "/download/%s/install.yaml"
+	latestURL       = releaseBaseURL + "/latest/download/install.yaml"
+)
+
+var installVersion string
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install the KubeCopilot operator into the cluster",
+	Long:  `Apply the KubeCopilot operator manifests (CRDs, RBAC, Deployment) from a GitHub release.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url := latestURL
+		if installVersion != "" && installVersion != defaultVersion {
+			url = fmt.Sprintf(manifestURLTmpl, installVersion)
+		}
+		fmt.Fprintf(os.Stdout, "Installing KubeCopilot operator from %s\n", url)
+		return runKubectl("apply", "-f", url)
+	},
+}
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall the KubeCopilot operator from the cluster",
+	Long:  `Remove the KubeCopilot operator manifests (CRDs, RBAC, Deployment) from the cluster.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url := latestURL
+		if installVersion != "" && installVersion != defaultVersion {
+			url = fmt.Sprintf(manifestURLTmpl, installVersion)
+		}
+		fmt.Fprintf(os.Stdout, "Uninstalling KubeCopilot operator using %s\n", url)
+		return runKubectl("delete", "--ignore-not-found", "-f", url)
+	},
+}
+
+func init() {
+	installCmd.Flags().StringVar(&installVersion, "version", defaultVersion, "operator release version (e.g. v1.0.0)")
+	rootCmd.AddCommand(installCmd)
+	rootCmd.AddCommand(uninstallCmd)
+}
+
+func runKubectl(args ...string) error {
+	kubectlArgs := args
+	if kubeconfig != "" {
+		kubectlArgs = append([]string{"--kubeconfig", kubeconfig}, kubectlArgs...)
+	}
+	if kubeCtx != "" {
+		kubectlArgs = append([]string{"--context", kubeCtx}, kubectlArgs...)
+	}
+	c := exec.Command("kubectl", kubectlArgs...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/cmd/cli/invoke.go
+++ b/cmd/cli/invoke.go
@@ -135,17 +135,17 @@ func streamChunks(ctx context.Context, c client.Client, sendName string) error {
 func printChunk(chunk agentv1.KubeCopilotChunk) {
 	switch chunk.Spec.ChunkType {
 	case "thinking":
-		fmt.Fprintf(os.Stderr, "[thinking] %s\n", chunk.Spec.Content)
+		_, _ = fmt.Fprintf(os.Stderr, "[thinking] %s\n", chunk.Spec.Content)
 	case "tool_call":
-		fmt.Fprintf(os.Stderr, "[tool] %s\n", chunk.Spec.Content)
+		_, _ = fmt.Fprintf(os.Stderr, "[tool] %s\n", chunk.Spec.Content)
 	case "tool_result":
-		fmt.Fprintf(os.Stderr, "[result] %s\n", chunk.Spec.Content)
+		_, _ = fmt.Fprintf(os.Stderr, "[result] %s\n", chunk.Spec.Content)
 	case "error":
-		fmt.Fprintf(os.Stderr, "[error] %s\n", chunk.Spec.Content)
+		_, _ = fmt.Fprintf(os.Stderr, "[error] %s\n", chunk.Spec.Content)
 	case "info":
-		fmt.Fprintf(os.Stderr, "[info] %s\n", chunk.Spec.Content)
+		_, _ = fmt.Fprintf(os.Stderr, "[info] %s\n", chunk.Spec.Content)
 	default:
-		fmt.Fprint(os.Stdout, chunk.Spec.Content)
+		_, _ = fmt.Fprint(os.Stdout, chunk.Spec.Content)
 	}
 }
 

--- a/cmd/cli/invoke.go
+++ b/cmd/cli/invoke.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentv1 "github.com/gfontana/kube-copilot-agent/api/v1"
+)
+
+var (
+	invokeAgent     string
+	invokeSessionID string
+	invokeTimeout   time.Duration
+)
+
+var invokeCmd = &cobra.Command{
+	Use:   "invoke <message>",
+	Short: "Send a message to a KubeCopilotAgent and stream the response",
+	Long: `Create a KubeCopilotSend CR with the given message and stream response
+chunks (KubeCopilotChunk) to stdout in real-time.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		message := args[0]
+
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		// Create the Send CR.
+		send := &agentv1.KubeCopilotSend{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: fmt.Sprintf("%s-send-", invokeAgent),
+				Namespace:    namespace,
+			},
+			Spec: agentv1.KubeCopilotSendSpec{
+				AgentRef:  invokeAgent,
+				Message:   message,
+				SessionID: invokeSessionID,
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), invokeTimeout)
+		defer cancel()
+
+		if err := c.Create(ctx, send); err != nil {
+			return fmt.Errorf("failed to create send: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Created send/%s — streaming response…\n", send.Name)
+
+		return streamChunks(ctx, c, send.Name)
+	},
+}
+
+// streamChunks watches KubeCopilotChunk resources and prints them ordered by
+// sequence. It stops once the corresponding KubeCopilotSend reaches a terminal
+// phase (Done or Error).
+func streamChunks(ctx context.Context, c client.Client, sendName string) error {
+	printed := 0
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for response")
+		case <-ticker.C:
+			// Fetch chunks matching this send.
+			var chunkList agentv1.KubeCopilotChunkList
+			if err := c.List(ctx, &chunkList, client.InNamespace(namespace),
+				client.MatchingFields{"spec.sendRef": sendName}); err != nil {
+				// Field selector may not be indexed; fall back to filtering.
+				if err := c.List(ctx, &chunkList, client.InNamespace(namespace)); err != nil {
+					return fmt.Errorf("failed to list chunks: %w", err)
+				}
+			}
+
+			// Filter and sort chunks for our send.
+			var relevant []agentv1.KubeCopilotChunk
+			for i := range chunkList.Items {
+				if chunkList.Items[i].Spec.SendRef == sendName {
+					relevant = append(relevant, chunkList.Items[i])
+				}
+			}
+			sort.Slice(relevant, func(i, j int) bool {
+				return relevant[i].Spec.Sequence < relevant[j].Spec.Sequence
+			})
+
+			// Print new chunks.
+			for _, chunk := range relevant {
+				if chunk.Spec.Sequence < printed {
+					continue
+				}
+				printChunk(chunk)
+				printed = chunk.Spec.Sequence + 1
+			}
+
+			// Check send status.
+			var send agentv1.KubeCopilotSend
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: sendName}, &send); err == nil {
+				switch send.Status.Phase {
+				case "Done":
+					return nil
+				case "Error":
+					return fmt.Errorf("agent returned error: %s", send.Status.ErrorMessage)
+				}
+			}
+		}
+	}
+}
+
+// printChunk outputs a single chunk to stdout.
+func printChunk(chunk agentv1.KubeCopilotChunk) {
+	switch chunk.Spec.ChunkType {
+	case "thinking":
+		fmt.Fprintf(os.Stderr, "[thinking] %s\n", chunk.Spec.Content)
+	case "tool_call":
+		fmt.Fprintf(os.Stderr, "[tool] %s\n", chunk.Spec.Content)
+	case "tool_result":
+		fmt.Fprintf(os.Stderr, "[result] %s\n", chunk.Spec.Content)
+	case "error":
+		fmt.Fprintf(os.Stderr, "[error] %s\n", chunk.Spec.Content)
+	case "info":
+		fmt.Fprintf(os.Stderr, "[info] %s\n", chunk.Spec.Content)
+	default:
+		fmt.Fprint(os.Stdout, chunk.Spec.Content)
+	}
+}
+
+func init() {
+	invokeCmd.Flags().StringVar(&invokeAgent, "agent", "", "name of the KubeCopilotAgent to invoke (required)")
+	invokeCmd.Flags().StringVar(&invokeSessionID, "session", "", "session ID for multi-turn conversation")
+	invokeCmd.Flags().DurationVar(&invokeTimeout, "timeout", 5*time.Minute, "maximum time to wait for response")
+	_ = invokeCmd.MarkFlagRequired("agent")
+	rootCmd.AddCommand(invokeCmd)
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentv1 "github.com/gfontana/kube-copilot-agent/api/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	kubeconfig string
+	namespace  string
+	kubeCtx    string
+
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(agentv1.AddToScheme(scheme))
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "kubecopilot",
+	Short: "CLI for managing KubeCopilot agents on Kubernetes",
+	Long: `kubecopilot is a command-line tool for installing, managing, and invoking
+KubeCopilot AI agents on Kubernetes and OpenShift clusters.`,
+}
+
+func init() {
+	defaultKubeconfig := ""
+	if home := homedir.HomeDir(); home != "" {
+		defaultKubeconfig = filepath.Join(home, ".kube", "config")
+	}
+	if envKubeconfig := os.Getenv("KUBECONFIG"); envKubeconfig != "" {
+		defaultKubeconfig = envKubeconfig
+	}
+
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", defaultKubeconfig, "path to the kubeconfig file")
+	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-copilot-agent", "target namespace")
+	rootCmd.PersistentFlags().StringVar(&kubeCtx, "context", "", "kubernetes context to use")
+}
+
+// getRestConfig builds a *rest.Config from CLI flags.
+func getRestConfig() (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		rules.ExplicitPath = kubeconfig
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if kubeCtx != "" {
+		overrides.CurrentContext = kubeCtx
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+}
+
+// getClient returns a controller-runtime client configured with the CRD scheme.
+func getClient() (client.Client, error) {
+	cfg, err := getRestConfig()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}

--- a/cmd/cli/session.go
+++ b/cmd/cli/session.go
@@ -19,8 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,15 +45,15 @@ var sessionListCmd = &cobra.Command{
 		if err := c.List(context.Background(), &list, client.InNamespace(namespace)); err != nil {
 			return fmt.Errorf("failed to list sessions: %w", err)
 		}
-		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tAGENT\tTENANT\tPHASE\tNAMESPACE\tAGE")
+		w := newStdoutTabWriterHelper()
+		w.Println("NAME\tAGENT\tTENANT\tPHASE\tNAMESPACE\tAGE")
 		for i := range list.Items {
 			s := &list.Items[i]
 			if sessionAgentFilter != "" && s.Spec.AgentRef != sessionAgentFilter {
 				continue
 			}
 			age := formatAge(s.CreationTimestamp.Time)
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			w.Printf("%s\t%s\t%s\t%s\t%s\t%s\n",
 				s.Name, s.Spec.AgentRef, s.Spec.TenantID,
 				s.Status.Phase, s.Status.Namespace, age)
 		}

--- a/cmd/cli/session.go
+++ b/cmd/cli/session.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentv1 "github.com/gfontana/kube-copilot-agent/api/v1"
+)
+
+var sessionAgentFilter string
+
+var sessionCmd = &cobra.Command{
+	Use:   "session",
+	Short: "Manage KubeCopilotSession resources",
+}
+
+var sessionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List KubeCopilotSession resources",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := getClient()
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		var list agentv1.KubeCopilotSessionList
+		if err := c.List(context.Background(), &list, client.InNamespace(namespace)); err != nil {
+			return fmt.Errorf("failed to list sessions: %w", err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tAGENT\tTENANT\tPHASE\tNAMESPACE\tAGE")
+		for i := range list.Items {
+			s := &list.Items[i]
+			if sessionAgentFilter != "" && s.Spec.AgentRef != sessionAgentFilter {
+				continue
+			}
+			age := formatAge(s.CreationTimestamp.Time)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Name, s.Spec.AgentRef, s.Spec.TenantID,
+				s.Status.Phase, s.Status.Namespace, age)
+		}
+		return w.Flush()
+	},
+}
+
+func init() {
+	sessionListCmd.Flags().StringVar(&sessionAgentFilter, "agent", "", "filter sessions by agent name")
+	sessionCmd.AddCommand(sessionListCmd)
+	rootCmd.AddCommand(sessionCmd)
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,113 @@
+# KubeCopilot CLI
+
+`kubecopilot` is a command-line tool for installing, managing, and invoking
+KubeCopilot AI agents on Kubernetes and OpenShift clusters.
+
+## Installation
+
+### Build from source
+
+```bash
+make build-cli
+```
+
+The binary is written to `bin/kubecopilot`.
+
+### As a kubectl plugin
+
+Symlink or rename the binary so that `kubectl` discovers it:
+
+```bash
+cp bin/kubecopilot /usr/local/bin/kubectl-kubecopilot
+kubectl kubecopilot --help
+```
+
+## Global Flags
+
+| Flag           | Default                | Description                     |
+| -------------- | ---------------------- | ------------------------------- |
+| `--kubeconfig` | `~/.kube/config`       | Path to the kubeconfig file     |
+| `--namespace`  | `kube-copilot-agent`   | Target namespace                |
+| `--context`    |                        | Kubernetes context to use       |
+
+## Commands
+
+### `install` — Install the operator
+
+Apply the KubeCopilot operator manifests from a GitHub release:
+
+```bash
+kubecopilot install                  # latest release
+kubecopilot install --version v1.0.0 # specific version
+```
+
+### `uninstall` — Remove the operator
+
+```bash
+kubecopilot uninstall
+```
+
+### `agent` — Manage agents
+
+```bash
+# List all agents
+kubecopilot agent list
+
+# Get details for a specific agent
+kubecopilot agent get my-agent
+
+# Create a new agent
+kubecopilot agent create my-agent \
+  --token-secret github-token \
+  --image ghcr.io/my-org/agent:latest \
+  --storage-size 5Gi
+
+# Delete an agent
+kubecopilot agent delete my-agent
+```
+
+### `invoke` — Send a message and stream the response
+
+```bash
+# One-shot message
+kubecopilot invoke --agent my-agent "List all pods in the cluster"
+
+# Continue an existing session
+kubecopilot invoke --agent my-agent --session abc123 "Now delete the crashlooping pod"
+
+# Custom timeout
+kubecopilot invoke --agent my-agent --timeout 10m "Run a full security audit"
+```
+
+The command creates a `KubeCopilotSend` CR and streams `KubeCopilotChunk`
+resources to stdout in real time, ordered by sequence number.
+
+### `session list` — List sessions
+
+```bash
+# All sessions
+kubecopilot session list
+
+# Filter by agent
+kubecopilot session list --agent my-agent
+```
+
+### `dashboard` — Port-forward the Web UI
+
+```bash
+kubecopilot dashboard              # forward to localhost:3000
+kubecopilot dashboard --port 8080  # forward to localhost:8080
+```
+
+## Examples
+
+```bash
+# Full workflow
+kubecopilot install
+kubecopilot agent create demo --token-secret my-gh-token
+kubecopilot invoke --agent demo "Hello, what can you do?"
+kubecopilot session list --agent demo
+kubecopilot dashboard
+kubecopilot agent delete demo
+kubecopilot uninstall
+```

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/spf13/cobra v1.10.0
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.0
@@ -38,20 +39,22 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/spf13/cobra v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -71,6 +73,8 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/v
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -98,6 +102,8 @@ github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -106,6 +112,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -36,8 +36,6 @@ const defaultNamespace = "default"
 
 var log = logf.Log.WithName("webhook-server")
 
-const defaultNamespace = "default"
-
 // +kubebuilder:rbac:groups=kubecopilot.io,resources=kubecopilotchunks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubecopilot.io,resources=kubecopilotchunks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kubecopilot.io,resources=kubecopilotresponses,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
## Summary

Implements a Cobra-based `kubecopilot` CLI binary (`cmd/cli/`) for installing, managing, and invoking KubeCopilot agents.

### Commands

| Command | Description |
|---------|-------------|
| `kubecopilot install [--version]` | Install operator manifests from GitHub release |
| `kubecopilot uninstall` | Remove operator |
| `kubecopilot agent list` | List KubeCopilotAgent CRs |
| `kubecopilot agent get <name>` | Get agent details |
| `kubecopilot agent create <name> --token-secret <s>` | Create agent |
| `kubecopilot agent delete <name>` | Delete agent |
| `kubecopilot invoke --agent <name> "message"` | Send message, stream response chunks |
| `kubecopilot session list [--agent <name>]` | List sessions |
| `kubecopilot dashboard [--port 3000]` | Port-forward web UI |

### Also included
- `make build-cli` Makefile target
- `docs/cli.md` documentation
- Fix: removed duplicate `defaultNamespace` in `internal/webhook/server.go`
- Works as a kubectl plugin (`kubectl-kubecopilot`)

Closes #16